### PR TITLE
Update index.py

### DIFF
--- a/OpsManage/views/index.py
+++ b/OpsManage/views/index.py
@@ -17,7 +17,7 @@ from django.contrib.auth.decorators import permission_required
 @login_required(login_url='/login')
 def index(request):
     #7天更新频率统计
-    userList = Project_Order.objects.raw('''SELECT id,order_user FROM opsmanage_project_order GROUP BY order_user;''')
+    userList = Project_Order.objects.raw('''SELECT id,order_user FROM opsmanage_project_order GROUP BY order_user,id;''')
     userList = [ u.order_user for u in userList ]
     dateList = [ base.getDaysAgo(num) for num in xrange(0,7) ][::-1]#将日期反序
     dataList = []


### PR DESCRIPTION
fix issue which is compatiable when running in MySQL 5.7
SQL Statement as below will failed as sql_mode is enhanced in 5.7
SELECT id,order_user FROM opsmanage_project_order GROUP BY order_user；
should be corrected as :
SELECT id,order_user FROM opsmanage_project_order GROUP BY order_user,id;
otherwise, errors will be as below:
(1055, "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'opsmanage.opsmanage_project_order.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")