### PR TITLE
删除ldap：python-ldap==3.2.0和ldap==1.0.2冲突的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6-slim
+
+WORKDIR /usr/src/app
+
+RUN apt update \
+ && apt install -y default-libmysqlclient-dev gcc python-dev libldap2-dev libsasl2-dev git \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
+
+COPY . .
+
+CMD [ "python", "./manage.py", "runserver", "0.0.0.0:8000" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ asn1crypto==0.24.0
 async-timeout==3.0.1
 attrs==18.2.0
 autobahn==18.10.1
+Automat==0.7.0
 bcrypt==3.1.4
 billiard==3.5.0.4
 celery==4.2.1
@@ -30,7 +31,10 @@ django-db==0.0.7
 django-timezone-field==3.0
 djangorestframework==3.9.0
 djangorestframework-jwt==1.11.0
+et-xmlfile==1.0.1
 future==0.15.2
+gitdb2==2.0.5
+GitPython==2.1.11
 hiredis==1.0.0
 httplib2==0.9.2
 hyperlink==18.0.0
@@ -39,7 +43,6 @@ incremental==17.5.0
 jdcal==1.4
 Jinja2==2.10
 kombu==4.2.1
-ldap==1.0.2
 ldap3==2.5.1
 MarkupSafe==1.1.0
 msgpack==0.5.6
@@ -63,13 +66,15 @@ PyJWT==1.6.4
 PyMySQL==0.9.2
 PyNaCl==1.2.1
 python-crontab==2.3.5
-python-ldap
+python-dateutil==2.8.0
+python-ldap==3.2.0
 python-magic==0.4.15
 pytz==2018.7
 PyYAML==3.13
 redis==2.10.6
 requests==2.20.0
 six==1.11.0
+smmap2==2.0.5
 tablib==0.12.1
 Twisted==18.9.0
 txaio==18.8.1
@@ -80,5 +85,3 @@ webencodings==0.5.1
 xlrd==1.1.0
 xlwt==1.3.0
 zope.interface==4.6.0
-ply==3.11
-GitPython==2.1.11


### PR DESCRIPTION
解决ImportError: cannot import name 'LDAPError'的错误
加入未添加的包(pip freeze命令输出的内容)